### PR TITLE
Add support for other id3 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Editing the buffer will update the tags. You can also rename the file by changin
 
 ## Dependencies
 
-### mp3
+### mp3 files
 
 To edit an mp3 file you need a command-line id3 tag editor installed.
 This plugin works with:
@@ -32,7 +32,7 @@ You should be able to install any of these with your system's package manager, f
 
     pacman -S id3
 
-### flac
+### flac files
 
 The plugin also supports FLAC files (somewhat misleadingly, since they don't use id3 tags). For those, you'll need the `metaflac` command, which, on Arch Linux, comes from the `flac` package:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The plugin also supports FLAC files (somewhat misleadingly, since they don't use
 
 On other platforms, you can probably use your favorite package manager to search for these.
 
-## Updating Genres using id3v2
+## Updating genres using id3v2
 
 The ID3 specification attributes a specific number to each genre.
 To edit the genre when using the `id3v2` tool with this plugin you just need to set the number inside the brackets to the correct genre identifier.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,33 @@ Edit an mp3 file. You'll see a buffer with its metadata stored as ID3 tags, form
     Genre:
     Comment:  Attribution 3.0
 
-Editing the buffer will update the tags. You can also rename the file by changing the value in the `File: ` section.
+Editing the buffer will update the tags. You can also rename the file by changing the value in the `File:` section.
 
-Note that, for mp3 files, this requires the `id3` command-line tool. On Arch Linux, this is available from the `id3` package, installable with:
+## Dependencies
+
+### mp3
+
+To edit an mp3 file you need a command-line id3 tag editor installed.
+This plugin works with:
+
+1. `id3`
+1. `id3v2`
+1. `id3tool`
+
+You should be able to install any of these with your system's package manager, for example on Arch Linux:
 
     pacman -S id3
+
+### flac
 
 The plugin also supports FLAC files (somewhat misleadingly, since they don't use id3 tags). For those, you'll need the `metaflac` command, which, on Arch Linux, comes from the `flac` package:
 
     pacman -S flac
 
 On other platforms, you can probably use your favorite package manager to search for these.
+
+## Updating Genres using id3v2
+
+The ID3 specification attributes a specific number to each genre.
+To edit the genre when using the `id3v2` tool with this plugin you just need to set the number inside the brackets to the correct genre identifier.
+When you write the buffer the text string in front of the brackets will be updated to match the number specified.

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -58,7 +58,7 @@ function! s:ReadMp3Id3Tool(filename)
   endif
 
   let tags = split(command_output, "\n")
-  let tags = map(tags, {key, value -> s:GetValueAfterColon(value)})
+  let tags = map(tags, {key, value -> s:FormatID3ToolValue(value)})
 
   call append(0, [
         \   'File: '.a:filename,
@@ -249,12 +249,19 @@ function! s:CheckCommand(command)
   endif
 endfunction
 
-function! s:GetValueAfterColon(string)
+function! s:FormatID3ToolValue(string)
   let contains_colon = stridx(a:string, ":")
   if contains_colon == -1
     return trim(a:string)
   else
-    return trim(strpart(a:string, contains_colon + 1))
+    " Remove the genre code returned with the genre string, as only one of
+    " those can be used when updating the values with id3tool
+    let string_value = a:string
+    if match(string_value, "Genre:") == 0
+      let string_value = substitute(string_value, '\s(0x[0-9]\{2})', "", "g")
+    endif
+
+    return trim(strpart(string_value, contains_colon + 1))
   endif
 endfunction
 

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -99,12 +99,12 @@ function! s:ReadMp3Id3v2(filename)
         \   'File: '.a:filename,
         \   repeat('=', len('File: '.a:filename)),
         \   '',
-        \   'Title:    '.s:GetV2Tag(tags, "TIT2"),
-        \   'Artist:   '.s:GetV2Tag(tags, "TPE1"),
-        \   'Album:    '.s:GetV2Tag(tags, "TALB"),
-        \   'Track No: '.s:GetV2Tag(tags, "TRCK"),
-        \   'Year:     '.s:GetV2Tag(tags, "TYER"),
-        \   'Genre:    '.s:GetV2Tag(tags, "TCON"),
+        \   'Title:    '.s:GetV2Tag(tags, "TIT2", "TT2"),
+        \   'Artist:   '.s:GetV2Tag(tags, "TPE1", "TP1"),
+        \   'Album:    '.s:GetV2Tag(tags, "TALB", "TAL"),
+        \   'Track No: '.s:GetV2Tag(tags, "TRCK", "TRK"),
+        \   'Year:     '.s:GetV2Tag(tags, "TYER", "TYE"),
+        \   'Genre:    '.s:GetV2Tag(tags, "TCON", "TCO"),
         \ ])
   $delete _
   call cursor(1, 1)
@@ -251,6 +251,8 @@ function! s:UpdateMp3Id3v2(filename)
   let tags.y = s:FindTagValue('Year')
   " Can only update genre through the code in id3v2
   let tags.g = matchstr(s:FindTagValue('Genre'), '([0-9]\{1,3})')
+  " Force band/orchestra/accompaniment to be same as Artist value
+  let tags["-TPE2"] = s:FindTagValue("Artist")
 
   let command_line = 'id3v2 '
   for [key, value] in items(tags)
@@ -348,8 +350,8 @@ function! s:FormatID3ToolValue(string)
   endif
 endfunction
 
-function! s:GetV2Tag(tag_list, tag_value) 
-  let required_tag = filter(copy(a:tag_list), {key, value -> s:MatchTag(value, a:tag_value) != ""})
+function! s:GetV2Tag(tag_list, tag_value, old_tag_value) 
+  let required_tag = filter(copy(a:tag_list), {key, value -> s:MatchTag(value, a:tag_value) != "" || s:MatchTag(value, a:old_tag_value) != ""})
   if empty(required_tag)
     return ""
   endif

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -351,7 +351,7 @@ endfunction
 function! s:GetV2Tag(tag_list, tag_value) 
   let required_tag = filter(copy(a:tag_list), {key, value -> s:MatchTag(value, a:tag_value) != ""})
   if empty(required_tag)
-    echoerr "Could not find a tag matching ".a:tag_value
+    return ""
   endif
   return trim(strpart(required_tag[0], stridx(required_tag[0], ":") + 1))
 endfunction

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -58,7 +58,7 @@ function! s:ReadMp3Id3Tool(filename)
   endif
 
   let tags = split(command_output, "\n")
-  let tags = map(tags, 'v:val != "<empty>" ? v:val : ""')
+  let tags = map(tags, {key, value -> s:GetValueAfterColon(value)})
 
   call append(0, [
         \   'File: '.a:filename,
@@ -203,6 +203,15 @@ function! s:CheckCommand(command)
     return 1
   else
     return 0
+  endif
+endfunction
+
+function! s:GetValueAfterColon(string)
+  let contains_colon = stridx(a:string, ":")
+  if contains_colon == -1
+    return trim(a:string)
+  else
+    return trim(strpart(a:string, contains_colon + 1))
   endif
 endfunction
 

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -1,6 +1,8 @@
 function! id3#ReadMp3(filename)
   if s:CheckCommand('id3')
     call s:ReadMp3Id3(a:filename)
+  elseif s:CheckCommand('id3v2')
+    call s:ReadMp3Id3V2(a:filename)
   elseif s:CheckCommand('id3tool')
     call s:ReadMp3Id3Tool(a:filename)
   else
@@ -70,6 +72,40 @@ function! s:ReadMp3Id3Tool(filename)
         \   'Track No: '.tags[4],
         \   'Year:     '.tags[5],
         \   'Genre:    '.tags[6],
+        \ ])
+  $delete _
+  call cursor(1, 1)
+
+  set filetype=audio.mp3
+endfunction
+
+function! s:ReadMp3Id3V2(filename)
+  if !filereadable(a:filename)
+    echoerr "File does not exist, can't open MP3 metadata: ".a:filename
+    return
+  endif
+
+  let filename       = shellescape(a:filename)
+  let command_output = system("id3v2 -R ".filename)
+
+  if v:shell_error
+    echoerr "There was an error executing the `id3v2` command: ".command_output
+    return
+  endif
+
+  let tags = split(command_output, "\n")
+  let tags = map(tags, {key, value -> s:FormatID3ToolValue(value)})
+
+  call append(0, [
+        \   'File: '.a:filename,
+        \   repeat('=', len('File: '.a:filename)),
+        \   '',
+        \   'Title:    '.tags[5],
+        \   'Artist:   '.tags[2],
+        \   'Album:    '.tags[1],
+        \   'Track No: '.tags[6],
+        \   'Year:     '.tags[7],
+        \   'Genre:    '.tags[3],
         \ ])
   $delete _
   call cursor(1, 1)

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -267,9 +267,10 @@ function! s:UpdateMp3Id3v2(filename)
   if new_filename != a:filename
     call rename(a:filename, new_filename)
     exe 'file '.fnameescape(new_filename)
-    %delete _
-    call id3#ReadMp3(new_filename)
   endif
+  " Call read again to display genre updates
+  %delete _
+  call id3#ReadMp3(new_filename)
 
   set nomodified
 endfunction

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -251,8 +251,6 @@ function! s:UpdateMp3Id3v2(filename)
   let tags.y = s:FindTagValue('Year')
   " Can only update genre through the code in id3v2
   let tags.g = matchstr(s:FindTagValue('Genre'), '([0-9]\{1,3})')
-  " Force band/orchestra/accompaniment to be same as Artist value
-  let tags["-TPE2"] = s:FindTagValue("Artist")
 
   let command_line = 'id3v2 '
   for [key, value] in items(tags)

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -360,6 +360,10 @@ endfunction
 
 function! s:MatchTag(value, expected_tag)
   let split_value = split(a:value, ":")
+  if empty(split_value)
+    return ""
+  endif
+
   if split_value[0] == a:expected_tag
     return trim(split_value[1])
   else

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -6,7 +6,7 @@ function! id3#ReadMp3(filename)
   elseif s:CheckCommand('id3tool')
     call s:ReadMp3Id3Tool(a:filename)
   else
-    echoerr "No suitable command-line tool found. Install one of: id3, id3tool"
+    echoerr "No suitable command-line tool found. Install one of: id3, id3v2, id3tool"
   endif
 endfunction
 

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -168,7 +168,7 @@ function! id3#UpdateMp3(filename)
   elseif s:CheckCommand('id3tool')
     call s:UpdateMp3Id3Tool(a:filename)
   else
-    echoerr "No suitable command-line tool found. Install one of: id3, id3tool"
+    echoerr "No suitable command-line tool found. Install one of: id3, id3v2, id3tool"
   endif
 endfunction
 
@@ -348,8 +348,20 @@ function! s:FormatID3ToolValue(string)
 endfunction
 
 function! s:GetV2Tag(tag_list, tag_value) 
-  let required_tag = filter(a:tag_list, {key, value -> match(value, a:tag_value)})[0]
-  return trim(strpart(required_tag, stridx(required_tag, ":") + 1))
+  let required_tag = filter(copy(a:tag_list), {key, value -> s:MatchTag(value, a:tag_value) != ""})
+  if empty(required_tag)
+    echoerr "Could not find a tag matching ".a:tag_value
+  endif
+  return trim(strpart(required_tag[0], stridx(required_tag[0], ":") + 1))
+endfunction
+
+function! s:MatchTag(value, expected_tag)
+  let split_value = split(a:value, ":")
+  if split_value[0] == a:expected_tag
+    return trim(split_value[1])
+  else
+    return ""
+  endif
 endfunction
 
 function! s:Upcase(string)

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -250,7 +250,7 @@ function! s:UpdateMp3Id3v2(filename)
   let tags.T = s:FindTagValue('Track No')
   let tags.y = s:FindTagValue('Year')
   " Can only update genre through the code in id3v2
-  " let tags.g = matchstr(s:FindTagValue('Genre'), '([0-9]\{1,3})')
+  let tags.g = matchstr(s:FindTagValue('Genre'), '([0-9]\{1,3})')
 
   let command_line = 'id3v2 '
   for [key, value] in items(tags)

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -94,18 +94,17 @@ function! s:ReadMp3Id3v2(filename)
   endif
 
   let tags = split(command_output, "\n")
-  let tags = map(tags, {key, value -> s:FormatID3ToolValue(value)})
 
   call append(0, [
         \   'File: '.a:filename,
         \   repeat('=', len('File: '.a:filename)),
         \   '',
-        \   'Title:    '.s:GetV2Tag(tags, "Title"),
-        \   'Artist:   '.s:GetV2Tag(tags, "Artist"),
-        \   'Album:    '.s:GetV2Tag(tags, "Album"),
-        \   'Track No: '.s:GetV2Tag(tags, "Track No"),
-        \   'Year:     '.s:GetV2Tag(tags, "Year"),
-        \   'Genre:    '.s:GetV2Tag(tags, "Genre"),
+        \   'Title:    '.s:GetV2Tag(tags, "TIT2"),
+        \   'Artist:   '.s:GetV2Tag(tags, "TPE1"),
+        \   'Album:    '.s:GetV2Tag(tags, "TALB"),
+        \   'Track No: '.s:GetV2Tag(tags, "TRCK"),
+        \   'Year:     '.s:GetV2Tag(tags, "TYER"),
+        \   'Genre:    '.s:GetV2Tag(tags, "TCON"),
         \ ])
   $delete _
   call cursor(1, 1)
@@ -348,22 +347,9 @@ function! s:FormatID3ToolValue(string)
   endif
 endfunction
 
-function! s:GetV2Tag(tag_list, tag_name)
-  if a:tag_name == "Title"
-    return "Title"
-  elseif a:tag_name == "Artist"
-    return "Artist"
-  elseif a:tag_name == "Album"
-    return "Album"
-  elseif a:tag_name == "Track No"
-    return "Track No"
-  elseif a:tag_name == "Year"
-    return "Year"
-  elseif a:tag_name == "Genre"
-    return "Genre"
-  else
-    echoerr "Invalid tag specified for id3v2 in GetV2Tag" + tag_name
-  endif
+function! s:GetV2Tag(tag_list, tag_value) 
+  let required_tag = filter(a:tag_list, {key, value -> match(value, a:tag_value)})[0]
+  return trim(strpart(required_tag, stridx(required_tag, ":") + 1))
 endfunction
 
 function! s:Upcase(string)

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -1,4 +1,14 @@
 function! id3#ReadMp3(filename)
+  if s:CheckCommand('id3')
+    call s:ReadMp3Id3(a:filename)
+  elseif s:CheckCommand('id3tool')
+    call s:ReadMp3Id3Tool(a:filename)
+  else
+    echoerr "No suitable command-line tool found. Install one of: id3, id3tool"
+  endif
+endfunction
+
+function! s:ReadMp3Id3(filename)
   if !filereadable(a:filename)
     echoerr "File does not exist, can't open MP3 metadata: ".a:filename
     return
@@ -31,6 +41,10 @@ function! id3#ReadMp3(filename)
   call cursor(1, 1)
 
   set filetype=audio.mp3
+endfunction
+
+function! s:ReadMp3Id3Tool(filename)
+    call s:ReadMp3Id3(a:filename)
 endfunction
 
 function! id3#ReadFlac(filename)
@@ -151,6 +165,15 @@ function! id3#UpdateFlac(filename)
   endif
 
   set nomodified
+endfunction
+
+function! s:CheckCommand(command)
+  call system('which '.a:command)
+  if v:shell_error == 0
+    return 1
+  else
+    return 0
+  endif
 endfunction
 
 function! s:FindTagValue(tag_name)

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -100,12 +100,12 @@ function! s:ReadMp3Id3v2(filename)
         \   'File: '.a:filename,
         \   repeat('=', len('File: '.a:filename)),
         \   '',
-        \   'Title:    '.tags[5],
-        \   'Artist:   '.tags[2],
-        \   'Album:    '.tags[1],
-        \   'Track No: '.tags[6],
-        \   'Year:     '.tags[7],
-        \   'Genre:    '.tags[3],
+        \   'Title:    '.s:GetV2Tag(tags, "Title"),
+        \   'Artist:   '.s:GetV2Tag(tags, "Artist"),
+        \   'Album:    '.s:GetV2Tag(tags, "Album"),
+        \   'Track No: '.s:GetV2Tag(tags, "Track No"),
+        \   'Year:     '.s:GetV2Tag(tags, "Year"),
+        \   'Genre:    '.s:GetV2Tag(tags, "Genre"),
         \ ])
   $delete _
   call cursor(1, 1)
@@ -345,6 +345,24 @@ function! s:FormatID3ToolValue(string)
     endif
 
     return trim(strpart(string_value, contains_colon + 1))
+  endif
+endfunction
+
+function! s:GetV2Tag(tag_list, tag_name)
+  if a:tag_name == "Title"
+    return "Title"
+  elseif a:tag_name == "Artist"
+    return "Artist"
+  elseif a:tag_name == "Album"
+    return "Album"
+  elseif a:tag_name == "Track No"
+    return "Track No"
+  elseif a:tag_name == "Year"
+    return "Year"
+  elseif a:tag_name == "Genre"
+    return "Genre"
+  else
+    echoerr "Invalid tag specified for id3v2 in GetV2Tag" + tag_name
   endif
 endfunction
 

--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -321,6 +321,17 @@ function! s:CheckCommand(command)
   endif
 endfunction
 
+function! s:FindTagValue(tag_name)
+  let tag_pattern = '^'.a:tag_name.':\s*\(.*\)$'
+  let tag_line    = search(tag_pattern, 'n')
+
+  if tag_line <= 0
+    return ''
+  endif
+
+  return substitute(getline(tag_line), tag_pattern, '\1', '')
+endfunction
+
 function! s:FormatID3ToolValue(string)
   let contains_colon = stridx(a:string, ":")
   if contains_colon == -1
@@ -335,17 +346,6 @@ function! s:FormatID3ToolValue(string)
 
     return trim(strpart(string_value, contains_colon + 1))
   endif
-endfunction
-
-function! s:FindTagValue(tag_name)
-  let tag_pattern = '^'.a:tag_name.':\s*\(.*\)$'
-  let tag_line    = search(tag_pattern, 'n')
-
-  if tag_line <= 0
-    return ''
-  endif
-
-  return substitute(getline(tag_line), tag_pattern, '\1', '')
 endfunction
 
 function! s:Upcase(string)


### PR DESCRIPTION
I had issues using this, as the version of `id3` I had didn't like the `-q` flag, so thought I'd update it to use `id3tool` as mentioned in #4 .
So I got that working although it turns out that didn't actually fix what I needed it to, as `id3tool` only writes v1 tags (probbbbably should have checked that first :facepalm: , but oh well).

So I'm also going to update it to handle using `id3v2` in the same manner (which **will** fix my use case), but figured it was worth keeping the `id3tool` bits in there as it fixes an issue someone else raised.